### PR TITLE
remove bom import if the parent already imports it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,15 +129,6 @@
         <version>${version.org.wildfly}</version>
       </dependency>
 
-      <!-- this also includes the org.jboss.spec:jboss-javaee-7.0 dependencies -->
-      <dependency>
-        <groupId>org.wildfly.bom</groupId>
-        <artifactId>jboss-javaee-7.0-with-logging</artifactId>
-        <version>${version.org.wildfly}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
merge this if https://github.com/hawkular/hawkular-parent-pom/pull/12 is merged (that is, if the parent POM imports wildfly BOM, we don't need to)
