### PR TITLE
give listeners access to the headers

### DIFF
--- a/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessage.java
+++ b/hawkular-bus-common/src/main/java/org/hawkular/bus/common/BasicMessage.java
@@ -16,6 +16,10 @@
  */
 package org.hawkular.bus.common;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -28,19 +32,20 @@ import com.google.gson.GsonBuilder;
  * usually left unset unless this message needs to be correlated with another. As an example, when a process is stopped,
  * you can correlate the "Stopped" event with the "Stopping" event so you can later determine how long it took for the
  * process to stop.
+ *
+ * The {@link #getHeaders() headers} are normally those out-of-band properties that are sent with the message.
  */
 public abstract class BasicMessage {
     // these are passed out-of-band of the message body - these attributes will therefore not be JSON encoded
-    private MessageId messageId;
-    private MessageId correlationId;
+    private MessageId _messageId;
+    private MessageId _correlationId;
+    private Map<String, String> _headers;
 
     /**
      * Convenience static method that converts a JSON string to a particular message object.
      *
-     * @param json
-     *            the JSON string
-     * @param clazz
-     *            the class whose instance is represented by the JSON string
+     * @param json the JSON string
+     * @param clazz the class whose instance is represented by the JSON string
      *
      * @return the message object that was represented by the JSON string
      */
@@ -70,11 +75,11 @@ public abstract class BasicMessage {
      * @return message ID assigned to this message by the messaging framework
      */
     public MessageId getMessageId() {
-        return messageId;
+        return _messageId;
     }
 
     public void setMessageId(MessageId messageId) {
-        this.messageId = messageId;
+        this._messageId = messageId;
     }
 
     /**
@@ -84,11 +89,49 @@ public abstract class BasicMessage {
      * @return the message ID of the correlated message
      */
     public MessageId getCorrelationId() {
-        return correlationId;
+        return _correlationId;
     }
 
     public void setCorrelationId(MessageId correlationId) {
-        this.correlationId = correlationId;
+        this._correlationId = correlationId;
+    }
+
+    /**
+     * The headers that were shipped along side of the message when the message was received.
+     * The returned map is an unmodifiable read-only view of the properties.
+     * Can return <code>null</code>.
+     *
+     * @return a read-only view of the name/value properties that came with the message as separate headers.
+     */
+    public Map<String, String> getHeaders() {
+        if (_headers == null) {
+            return null;
+        }
+        return Collections.unmodifiableMap(_headers);
+    }
+
+    /**
+     * Sets headers that will be sent with the message when the message gets delivered.
+     * This completely replaces any existing headers already associated with this message.
+     * Note that the given name/value pairs will be copied to an internal map.
+     * If the given map is null, this message's internal map will be destroyed.
+     *
+     * Note that the header values are all expected to be strings.
+     *
+     * @param headers name/value properties
+     */
+    public void setHeaders(Map<String, String> headers) {
+        if (headers == null) {
+            this._headers = null;
+        } else {
+            if (this._headers == null) {
+                this._headers = new HashMap<String, String>(headers);
+            } else {
+                // we want to replace what we had with the new headers
+                this._headers.clear();
+                this._headers.putAll(headers);
+            }
+        }
     }
 
     @Override
@@ -98,6 +141,8 @@ public abstract class BasicMessage {
         str.append(getMessageId());
         str.append(", correlation-id=");
         str.append(getCorrelationId());
+        str.append(", headers=");
+        str.append(getHeaders());
         str.append(", json-body=[");
         str.append(toJSON());
         str.append("]]");

--- a/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/AbstractBasicMessageListener.java
+++ b/hawkular-bus-common/src/main/java/org/hawkular/bus/common/consumer/AbstractBasicMessageListener.java
@@ -19,6 +19,8 @@ package org.hawkular.bus.common.consumer;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Enumeration;
+import java.util.HashMap;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -104,6 +106,15 @@ public abstract class AbstractBasicMessageListener<T extends BasicMessage> imple
                 basicMessage.setCorrelationId(correlationId);
             }
 
+            HashMap<String, String> rawHeaders = new HashMap<String, String>();
+            for (Enumeration<?> propNames = message.getPropertyNames(); propNames.hasMoreElements();) {
+                String propName = propNames.nextElement().toString();
+                rawHeaders.put(propName, message.getStringProperty(propName));
+            }
+            if (!rawHeaders.isEmpty()) {
+                basicMessage.setHeaders(rawHeaders);
+            }
+
             getLog().tracef("Received basic message: %s", basicMessage);
         } catch (JMSException e) {
             msglog.errorNotValidTextMessage(e);
@@ -131,6 +142,7 @@ public abstract class AbstractBasicMessageListener<T extends BasicMessage> imple
      *
      * @return class of T
      */
+    @SuppressWarnings("unchecked")
     protected Class<T> determineBasicMessageClass() {
         // all of this is usually going to just return BasicMessage.class - but in case there is a subclass hierarchy
         // that makes it more specific, this will help discover the message class.

--- a/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageTest.java
+++ b/hawkular-bus-common/src/test/java/org/hawkular/bus/common/BasicMessageTest.java
@@ -28,6 +28,43 @@ import org.junit.Test;
 
 public class BasicMessageTest {
 
+    @Test
+    public void testHeaders() {
+        // we don't get headers by default
+        BasicMessage msg = new SimpleBasicMessage("my msg");
+        assertNull(msg.getHeaders());
+
+        // the headers are copied internally
+        Map<String, String> headers = new HashMap<String, String>();
+        msg.setHeaders(headers);
+        assertNotNull(msg.getHeaders());
+        assertNotSame(headers, msg.getHeaders());
+
+        // we can't change the headers via the map returned by the getter
+        try {
+            msg.getHeaders().put("not-allowed", "not-allowed");
+            assert false : "Should not have been allowed to modify the returned map";
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+
+        // show that the setter completely replaces the old headers
+        assertEquals(0, msg.getHeaders().size());
+        headers.put("one", "111");
+        headers.put("two", "222");
+        msg.setHeaders(headers);
+        assertEquals(2, msg.getHeaders().size());
+        assertEquals("111", msg.getHeaders().get("one"));
+        assertEquals("222", msg.getHeaders().get("two"));
+
+        headers.clear();
+        assertEquals("Clearing our map should not have affected the msg internal map", 2, msg.getHeaders().size());
+        headers.put("foo", "bar");
+        msg.setHeaders(headers);
+        assertEquals(1, msg.getHeaders().size());
+        assertEquals("bar", msg.getHeaders().get("foo"));
+    }
+
     // tests a minimal basic record with no details
     @Test
     public void simpleConversion() {


### PR DESCRIPTION
allow one to set headers directly in the message that will be used when sending
