### PR TITLE
Add MVCC mode to H2 datasource

### DIFF
--- a/hawkular-nest/hawkular-nest-distro/src/main/scripts/standalone.xsl
+++ b/hawkular-nest/hawkular-nest-distro/src/main/scripts/standalone.xsl
@@ -160,7 +160,7 @@
   <xsl:template name="datasources">
     <datasources>
         <datasource jta="true" jndi-name="java:jboss/datasources/HawkularDS" pool-name="HawkularDS" enabled="true" use-ccm="true">
-        <connection-url>jdbc:h2:${jboss.server.data.dir}/hawkular_db</connection-url>
+        <connection-url>jdbc:h2:${jboss.server.data.dir}/hawkular_db;MVCC=TRUE</connection-url>
         <driver-class>org.h2.Driver</driver-class>
         <driver>h2</driver>
         <security>


### PR DESCRIPTION
There are some concurrency issues in H2 that are solved updating datasource url with mvcc mode.
https://issues.jboss.org/browse/HWKALERTS-27
