### PR TITLE
HAWKULAR-382 Replace gson library by jackson

### DIFF
--- a/hawkular-bus-common/pom.xml
+++ b/hawkular-bus-common/pom.xml
@@ -73,13 +73,14 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageId.java
+++ b/hawkular-bus-common/src/main/java/org/hawkular/bus/common/MessageId.java
@@ -22,6 +22,10 @@ package org.hawkular.bus.common;
 public class MessageId {
     private final String id;
 
+    public MessageId() {
+        this.id = null;
+    }
+
     public MessageId(String id) {
         if (id == null || id.length() == 0) {
             throw new IllegalArgumentException("ID cannot be null or empty");

--- a/hawkular-bus-common/src/main/java/org/hawkular/bus/common/SimpleBasicMessage.java
+++ b/hawkular-bus-common/src/main/java/org/hawkular/bus/common/SimpleBasicMessage.java
@@ -20,18 +20,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.gson.annotations.Expose;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 /**
  * A simple message that is sent over the message bus.
  */
 public class SimpleBasicMessage extends BasicMessage {
     // the basic message body - it will be exposed to the JSON output
-    @Expose
+    @JsonInclude
     private String message;
 
     // some optional additional details about the basic message
-    @Expose
+    @JsonInclude
     private Map<String, String> details;
 
     protected SimpleBasicMessage() {

--- a/hawkular-bus-common/src/test/java/org/hawkular/bus/common/ObjectMessageTest.java
+++ b/hawkular-bus-common/src/test/java/org/hawkular/bus/common/ObjectMessageTest.java
@@ -27,8 +27,10 @@ public class ObjectMessageTest {
             assert false : "should have failed - didn't tell it the class";
         } catch (IllegalStateException expected) {
         }
-
-        msg.setMessage("foo");
+        /*
+            Jackson library needs quotes for single json string representation
+         */
+        msg.setMessage("\"foo\"");
         msg.setObjectClass(String.class);
         Object o = msg.getObject();
         assert o.getClass() == String.class;

--- a/hawkular-bus-samples/hawkular-bus-sample-client/pom.xml
+++ b/hawkular-bus-samples/hawkular-bus-sample-client/pom.xml
@@ -36,6 +36,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/hawkular-bus-samples/hawkular-bus-sample-jsonschema/pom.xml
+++ b/hawkular-bus-samples/hawkular-bus-sample-jsonschema/pom.xml
@@ -36,6 +36,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -51,7 +55,7 @@
         <configuration>
           <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
           <targetPackage>org.hawkular.bus.sample.msg</targetPackage>
-          <annotationStyle>gson</annotationStyle>
+          <annotationStyle>jackson</annotationStyle>
           <includeToString>false</includeToString>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
           <initializeCollections>true</initializeCollections>

--- a/hawkular-bus-test-common/pom.xml
+++ b/hawkular-bus-test-common/pom.xml
@@ -46,6 +46,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hawkular-bus-test-common/src/test/java/org/hawkular/bus/common/test/SpecificMessage.java
+++ b/hawkular-bus-test-common/src/test/java/org/hawkular/bus/common/test/SpecificMessage.java
@@ -16,18 +16,20 @@
  */
 package org.hawkular.bus.common.test;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
-
 import org.hawkular.bus.common.SimpleBasicMessage;
-
-import com.google.gson.annotations.Expose;
 
 /**
  * Test subclass of BasicMessage.
  */
 public class SpecificMessage extends SimpleBasicMessage {
-    @Expose
+    @JsonInclude
     private final String specific;
+
+    public SpecificMessage() {
+        this.specific = null;
+    }
 
     public SpecificMessage(String message, Map<String, String> details, String specific) {
         super(message, details);

--- a/hawkular-nest/hawkular-nest-distro/pom.xml
+++ b/hawkular-nest/hawkular-nest-distro/pom.xml
@@ -134,7 +134,7 @@
               </includeArtifactIds>
               <stripVersion>true</stripVersion>
               <stripClassifier>true</stripClassifier>
-              <overWriteIfNew>true</overWriteIfNew>
+              <overWriteIfNewer>true</overWriteIfNewer>
               <excludeTransitive>true</excludeTransitive>
             </configuration>
           </execution>

--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/module/main/module.xml
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/module/main/module.xml
@@ -25,7 +25,6 @@
     <resource-root path="${project.build.finalName}.jar" />
     <resource-root path="hawkular-bus-common-${project.version}.jar" />
     <resource-root path="hawkular-bus-mdb-${project.version}.jar" />
-    <resource-root path="gson-${version.com.google.code.gson}.jar" />
   </resources>
 
   <dependencies>


### PR DESCRIPTION
This PR replaces gson library (not included by default in Wildfly) by jackson lib.
With this change, all API used by REST interfaces in hawkular can be re-used in the bus API without adding specific GSON dependencies.
Major change from user perspective is that the @Expose annotation should be replaced by jackson's @JsonInclude and @JsonIgnore.
I checked the unit tests, but I would like to run more integration tests before to merge.
@jmazzitelli please, can you review and suggest how to perform more tests ?
I have doubts if in nest we need some specific export library.
Also, once this PR is merged, clients should update their @Expose annotations by @JsonInclude and @JsonIgnore ones.
