### PR TITLE
HAWKULAR-446 Fix missing jackson dependencies on bus

### DIFF
--- a/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/module/main/module.xml
+++ b/hawkular-nest/hawkular-nest-wf-extension/src/main/resources/module/main/module.xml
@@ -41,6 +41,9 @@
     <module name="org.jboss.vfs" />
 
     <!-- other dependencies we need -->
+    <module name="com.fasterxml.jackson.core.jackson-core" export="true" />
+    <module name="com.fasterxml.jackson.core.jackson-databind" export="true" />
+    <module name="com.fasterxml.jackson.core.jackson-annotations" export="true" />
     <module name="com.google.guava" export="true" />
     <module name="gnu.getopt" />
     <module name="javax.jms.api"  export="true" />


### PR DESCRIPTION
Thx for the review @jmazzitelli .
There were missing dependencies on the module.xml of the extension, then the jackson libraries were not exposed to the customer.
For this PR, I tested manually the sample-mdb app and I could reproduce the issue and fix it with this patch.
Please, take a look on it and merge if you think it's right.
Lucas 
